### PR TITLE
Fixing broken link to question_answering page

### DIFF
--- a/docs/docs/use_cases/question_answering/code_understanding.ipynb
+++ b/docs/docs/use_cases/question_answering/code_understanding.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "## Overview\n",
     "\n",
-    "The pipeline for QA over code follows [the steps we do for document question answering](/docs/docs/use_cases/question_answering), with some differences:\n",
+    "The pipeline for QA over code follows [the steps we do for document question answering](/docs/use_cases/question_answering), with some differences:\n",
     "\n",
     "In particular, we can employ a [splitting strategy](https://python.langchain.com/docs/integrations/document_loaders/source_code) that does a few things:\n",
     "\n",


### PR DESCRIPTION
Description: Updating the documentation page to provide a reference link to correct page
Issue: While reading the documentation observed, there is a broken link. This PR is to update with correct link.

Following was present before:
~~~
The pipeline for QA over code follows [the steps we do for document question answering](/docs/docs/use_cases/question_answering), with some differences: 
~~~

Following is the proposed:
~~~
The pipeline for QA over code follows [the steps we do for document question answering](/docs/use_cases/question_answering), with some differences:   
~~~

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
